### PR TITLE
Fix error handling when there is no response

### DIFF
--- a/lib/chatgpt/client.rb
+++ b/lib/chatgpt/client.rb
@@ -99,8 +99,9 @@ module ChatGPT
         # Parse and return the response body
         JSON.parse(response.body)
       rescue RestClient::ExceptionWithResponse => e
-        # Parse the error message from the API response
-        error_msg = JSON.parse(e.response.body)['error']['message']
+        error_msg = 'No error message'
+        # Parse the error message from the API response if there is a response
+        error_msg = JSON.parse(e.response.body)['error']['message'] if e.response
         
         # Raise an exception with the API error message
         raise RestClient::ExceptionWithResponse.new("#{e.message}: #{error_msg} (#{e.http_code})"), nil, e.backtrace


### PR DESCRIPTION
Even though the exception name suggests otherwise, sometimes the `response` in the exception is nil. Trying to call `body` on it, then results in the following exception:

```
NoMethodError: undefined method `body' for nil:NilClass

        error_msg = JSON.parse(e.response.body)['error']['message']
```

So, it seems that we need to check for the existence of a body, before we try to parse it.